### PR TITLE
Simplify CI and make sure use python 3.8 in all CI steps

### DIFF
--- a/.github/CI_SETUP.md
+++ b/.github/CI_SETUP.md
@@ -57,11 +57,17 @@ strategy:
 
 **Purpose**: Comprehensive integration testing with coverage
 
-**Features**:
-- **Testing**: Full pytest suite with 80% coverage threshold
-- **Linting**: Code formatting checks with black
-- **Building**: Package building and validation
-- **Coverage**: Upload to Codecov with detailed reporting
+**Jobs**:
+1. **test**: Full testing pipeline
+   - Install SLEAP PyPI + package with dev dependencies
+   - Run linting with black
+   - Run pytest with coverage
+   - Upload coverage to Codecov
+   - Check 80% coverage threshold
+2. **build**: Package building and validation
+   - Build wheel and sdist
+   - Validate with twine
+   - Upload build artifacts
 
 **Dependencies**:
 ```bash

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
     - name: Set up Python 3.8
       uses: actions/setup-python@v5
       with:
-        python-version: 3.8
+        python-version: '3.8'
     
     - name: Cache pip packages
       uses: actions/cache@v4
@@ -83,7 +83,7 @@ jobs:
     - name: Set up Python 3.8
       uses: actions/setup-python@v5
       with:
-        python-version: 3.8
+        python-version: '3.8'
     
     - name: Install build dependencies
       run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,25 +9,22 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        python-version: ["3.8"]
     
     steps:
     - uses: actions/checkout@v4
     
-    - name: Set up Python ${{ matrix.python-version }}
+    - name: Set up Python 3.8
       uses: actions/setup-python@v5
       with:
-        python-version: ${{ matrix.python-version }}
+        python-version: 3.8
     
     - name: Cache pip packages
       uses: actions/cache@v4
       with:
         path: ~/.cache/pip
-        key: ${{ runner.os }}-pip-${{ matrix.python-version }}-${{ hashFiles('**/pyproject.toml') }}
+        key: ${{ runner.os }}-pip-3.8-${{ hashFiles('**/pyproject.toml') }}
         restore-keys: |
-          ${{ runner.os }}-pip-${{ matrix.python-version }}-
+          ${{ runner.os }}-pip-3.8-
           ${{ runner.os }}-pip-
     
     - name: Install system dependencies for SLEAP
@@ -38,14 +35,12 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        # Install SLEAP via PyPI
         pip install sleap[pypi]==1.4.1
-        # Then install our package with dev dependencies
         pip install -e .[dev]
     
     - name: Run linting
       run: |
-        black --check sleap_roots_training/ tests/
+        black --check --diff sleap_roots_training/ tests/
     
     - name: Run tests with coverage
       run: |
@@ -58,15 +53,6 @@ jobs:
         flags: unittests
         name: codecov-umbrella
         fail_ci_if_error: false
-    
-    - name: Upload coverage reports as artifact
-      uses: actions/upload-artifact@v4
-      if: matrix.python-version == '3.9'
-      with:
-        name: coverage-reports
-        path: |
-          coverage.xml
-          htmlcov/
     
     - name: Check coverage threshold
       run: |
@@ -88,45 +74,16 @@ jobs:
           exit 1
         fi
 
-
-  lint:
-    runs-on: ubuntu-latest
-    
-    steps:
-    - uses: actions/checkout@v4
-    
-    - name: Set up Python 3.9
-      uses: actions/setup-python@v5
-      with:
-        python-version: 3.9
-    
-    - name: Install dependencies
-      run: |
-        python -m pip install --upgrade pip
-        pip install black
-    
-    - name: Run black formatter check
-      run: |
-        black --check --diff sleap_roots_training/ tests/
-    
-    - name: Run black formatter (show what would be changed)
-      if: failure()
-      run: |
-        echo "The following files would be reformatted:"
-        black --check --diff sleap_roots_training/ tests/ || true
-        echo ""
-        echo "To fix formatting issues, run: black sleap_roots_training/ tests/"
-
   build:
     runs-on: ubuntu-latest
     
     steps:
     - uses: actions/checkout@v4
     
-    - name: Set up Python 3.9
+    - name: Set up Python 3.8
       uses: actions/setup-python@v5
       with:
-        python-version: 3.9
+        python-version: 3.8
     
     - name: Install build dependencies
       run: |
@@ -146,24 +103,3 @@ jobs:
       with:
         name: build-artifacts
         path: dist/
-
-  coverage-report:
-    runs-on: ubuntu-latest
-    needs: test
-    if: github.event_name == 'pull_request'
-    
-    steps:
-    - uses: actions/checkout@v4
-    
-    - name: Download coverage reports
-      uses: actions/download-artifact@v4
-      with:
-        name: coverage-reports
-    
-    - name: Coverage Comment
-      uses: py-cov-action/python-coverage-comment-action@v3
-      with:
-        GITHUB_TOKEN: ${{ github.token }}
-        COMMENT_FILENAME: coverage.xml
-        MINIMUM_GREEN: 80
-        MINIMUM_ORANGE: 60

--- a/README.md
+++ b/README.md
@@ -199,7 +199,9 @@ The project uses streamlined GitHub Actions workflows for comprehensive testing:
    - **Runs on**: Ubuntu (primary)
    - **Python**: 3.8
    - **SLEAP**: PyPI version
-   - **Features**: Comprehensive test suite, code coverage (80% threshold), linting, building
+   - **Jobs**: 
+     - **test**: Testing, linting, coverage (80% threshold), Codecov upload
+     - **build**: Package building and validation
    - **Triggers**: Every push and PR
 
 ### Why This Setup?


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Improved CI workflow documentation in both the CI setup guide and README for greater clarity, detailing the specific steps in testing and building jobs.

* **Chores**
  * Streamlined the CI workflow by standardizing on Python 3.8, removing multi-version testing, consolidating linting into the test job, and simplifying coverage handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->